### PR TITLE
Implement registration

### DIFF
--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -1,0 +1,80 @@
+package rs.raf.userservice.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
+import rs.raf.userservice.dto.user.UserResponseDTO;
+import rs.raf.userservice.service.UserService;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+    private final UserService service;
+
+    public UserController(UserService service) {
+        this.service = service;
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "204", description = "No content")
+    })
+    @GetMapping
+    public ResponseEntity<List<UserResponseDTO>> getAll() {
+        var response = service.getAll();
+        if (response.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "404", description = "Not found")
+    })
+    @Parameter(name = "id", description = "ID of the user to retrieve", required = true)
+    @GetMapping("/{id}")
+    public ResponseEntity<UserResponseDTO> getById(@PathVariable Long id) {
+        var response = service.getById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "404", description = "Not found")
+    })
+    @Parameter(name = "username", description = "Username of the user to retrieve", required = true)
+    @GetMapping("/{username}")
+    public ResponseEntity<UserResponseDTO> getByUsername(@PathVariable String username) {
+        var response = service.getByUsername(username);
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "409", description = "Conflict")
+    })
+    @Parameter(name = "requestDTO", description = "User registration data", required = true)
+    @PostMapping
+    public ResponseEntity<UserResponseDTO> registerUser(
+            @RequestBody @Valid RegisterUserRequestDTO requestDTO,
+            HttpServletRequest httpRequest
+    ) {
+        String ip = httpRequest.getRemoteAddr();
+        var response = service.registerUser(requestDTO, ip);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -67,7 +67,7 @@ public class UserController {
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "409", description = "Conflict")
     })
-    @Parameter(name = "requestDTO", description = "User registration data", required = true)
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User registration data", required = true)
     @PostMapping
     public ResponseEntity<UserResponseDTO> registerUser(
             @RequestBody @Valid RegisterUserRequestDTO requestDTO,
@@ -75,6 +75,6 @@ public class UserController {
     ) {
         String ip = httpRequest.getRemoteAddr();
         var response = service.registerUser(requestDTO, ip);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.created(null).body(response);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -64,7 +64,8 @@ public class UserController {
     }
 
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "201", description = "Created"),
+        @ApiResponse(responseCode = "400", description = "Bad request"),
         @ApiResponse(responseCode = "409", description = "Conflict")
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User registration data", required = true)
@@ -75,6 +76,6 @@ public class UserController {
     ) {
         String ip = httpRequest.getRemoteAddr();
         var response = service.registerUser(requestDTO, ip);
-        return ResponseEntity.created(null).body(response);
+        return ResponseEntity.status(201).body(response);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -57,7 +57,7 @@ public class UserController {
         @ApiResponse(responseCode = "404", description = "Not found")
     })
     @Parameter(name = "username", description = "Username of the user to retrieve", required = true)
-    @GetMapping("/{username}")
+    @GetMapping("/username/{username}")
     public ResponseEntity<UserResponseDTO> getByUsername(@PathVariable String username) {
         var response = service.getByUsername(username);
         return ResponseEntity.ok(response);

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/ErrorResponseDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/ErrorResponseDTO.java
@@ -1,0 +1,9 @@
+package rs.raf.userservice.dto;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponseDTO(
+    int status,
+    LocalDateTime timestamp,
+    String message
+) {}

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/user/RegisterUserRequestDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/user/RegisterUserRequestDTO.java
@@ -13,6 +13,7 @@ public record RegisterUserRequestDTO(
     @NotBlank
     String password,
     @Schema(description = "Email of the new user", example = "jdoe@example.com")
+    @NotBlank
     @Email
     String email,
     @Schema(description = "First name of the new user", example = "John")

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/user/RegisterUserRequestDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/user/RegisterUserRequestDTO.java
@@ -1,0 +1,22 @@
+package rs.raf.userservice.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "DTO for registering a new user")
+public record RegisterUserRequestDTO(
+    @Schema(description = "Username of the new user", example = "john_doe")
+    @NotBlank
+    String username,
+    @Schema(description = "Password of the new user", example = "P@ssw0rd!")
+    @NotBlank
+    String password,
+    @Schema(description = "Email of the new user", example = "jdoe@example.com")
+    @Email
+    String email,
+    @Schema(description = "First name of the new user", example = "John")
+    String firstName,
+    @Schema(description = "Last name of the new user", example = "Doe")
+    String lastName
+) {}

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/user/UserResponseDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/user/UserResponseDTO.java
@@ -1,0 +1,21 @@
+package rs.raf.userservice.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+
+@Schema(description = "Data Transfer Object for user response")
+public record UserResponseDTO(
+    @Schema(description = "Unique identifier of the user", example = "1")
+    Long id,
+    @Schema(description = "Username of the user", example = "john_doe")
+    String username,
+    @Schema(description = "Email of the new user", example = "jdoe@example.com")
+    @Email
+    String email,
+    @Schema(description = "First name of the user", example = "John")
+    String firstName,
+    @Schema(description = "Last name of the user", example = "Doe")
+    String lastName,
+    @Schema(description = "Role of the user", example = "CUSTOMER")
+    String role
+) {}

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package rs.raf.userservice.error;
+
+import java.time.LocalDateTime;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import rs.raf.userservice.dto.ErrorResponseDTO;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ErrorResponseDTO> handleUserNotFoundException(UserNotFoundException ex) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            404,
+            LocalDateTime.now(),
+            ex.getMessage()
+        );
+        return ResponseEntity.status(404).body(errorResponse);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package rs.raf.userservice.error;
 import java.time.LocalDateTime;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
@@ -28,5 +29,17 @@ public class GlobalExceptionHandler {
             ex.getMessage()
         );
         return ResponseEntity.status(409).body(errorResponse);
+    }
+
+    // Not great, but it works for now
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDTO> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            400,
+            LocalDateTime.now(),
+            errorMessage
+        );
+        return ResponseEntity.status(400).body(errorResponse);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -34,11 +34,14 @@ public class GlobalExceptionHandler {
     // Not great, but it works for now
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDTO> handleValidationExceptions(MethodArgumentNotValidException ex) {
-        String errorMessage = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        StringBuilder errorMessage = new StringBuilder("Validation failed:\n");
+        ex.getBindingResult().getFieldErrors().forEach(error -> {
+            errorMessage.append(String.format("Field '%s': %s\n", error.getField(), error.getDefaultMessage()));
+        });
         ErrorResponseDTO errorResponse = new ErrorResponseDTO(
             400,
             LocalDateTime.now(),
-            errorMessage
+            errorMessage.toString().trim()
         );
         return ResponseEntity.status(400).body(errorResponse);
     }

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -19,4 +19,14 @@ public class GlobalExceptionHandler {
         );
         return ResponseEntity.status(404).body(errorResponse);
     }
+
+    @ExceptionHandler(UserAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponseDTO> handleUserAlreadyExistsException(UserAlreadyExistsException ex) {
+        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
+            409,
+            LocalDateTime.now(),
+            ex.getMessage()
+        );
+        return ResponseEntity.status(409).body(errorResponse);
+    }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/UserAlreadyExistsException.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/UserAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package rs.raf.userservice.error;
+
+public class UserAlreadyExistsException extends RuntimeException {
+    public UserAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/UserNotFoundException.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package rs.raf.userservice.error;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
@@ -1,0 +1,31 @@
+package rs.raf.userservice.mapper;
+
+import org.springframework.stereotype.Component;
+
+import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
+import rs.raf.userservice.dto.user.RegisterUserResponseDTO;
+import rs.raf.userservice.dto.user.UserResponseDTO;
+import rs.raf.userservice.model.User;
+
+@Component
+public class UserMapper {
+    public User toEntity(RegisterUserRequestDTO dto) {
+        return new User()
+            .setUsername(dto.username())
+            .setPassword(dto.password())
+            .setEmail(dto.email())
+            .setFirstName(dto.firstName())
+            .setLastName(dto.lastName());
+    }
+
+    public UserResponseDTO toDTO(User user) {
+        return new UserResponseDTO(
+            user.getId(),
+            user.getUsername(),
+            user.getEmail(),
+            user.getFirstName(),
+            user.getLastName(),
+            user.getRole().name()
+        );
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
@@ -5,16 +5,18 @@ import org.springframework.stereotype.Component;
 import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
 import rs.raf.userservice.dto.user.UserResponseDTO;
 import rs.raf.userservice.model.User;
+import rs.raf.userservice.model.UserRole;
 
 @Component
 public class UserMapper {
     public User toEntity(RegisterUserRequestDTO dto) {
         return new User()
             .setUsername(dto.username())
-            .setPassword(dto.password())
+            .setPassword(dto.password()) // TODO: hash passwords
             .setEmail(dto.email())
             .setFirstName(dto.firstName())
-            .setLastName(dto.lastName());
+            .setLastName(dto.lastName())
+            .setRole(UserRole.CUSTOMER);
     }
 
     public UserResponseDTO toDTO(User user) {

--- a/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
@@ -3,7 +3,6 @@ package rs.raf.userservice.mapper;
 import org.springframework.stereotype.Component;
 
 import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
-import rs.raf.userservice.dto.user.RegisterUserResponseDTO;
 import rs.raf.userservice.dto.user.UserResponseDTO;
 import rs.raf.userservice.model.User;
 

--- a/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
@@ -1,0 +1,51 @@
+package rs.raf.userservice.service;
+
+import java.util.List;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+import rs.raf.userservice.dto.user.*;
+import rs.raf.userservice.error.UserAlreadyExistsException;
+import rs.raf.userservice.error.UserNotFoundException;
+import rs.raf.userservice.mapper.UserMapper;
+import rs.raf.userservice.model.User;
+import rs.raf.userservice.repository.UserRepository;
+
+@Service
+public class UserService {
+    private final UserRepository repo;
+    private final UserMapper mapper;
+
+    public UserService(UserRepository repo, UserMapper mapper) {
+        this.repo = repo;
+        this.mapper = mapper;
+    }
+
+    public List<UserResponseDTO> getAll() {
+        return repo.findAll().stream().map(mapper::toDTO).toList();
+    }
+
+    public UserResponseDTO getById(Long id) {
+        return repo.findById(id)
+            .map(mapper::toDTO)
+            .orElseThrow(() -> new UserNotFoundException("User with id " + id + " not found"));
+    }
+
+    public UserResponseDTO getByUsername(String username) {
+        return repo.findByUsername(username)
+            .map(mapper::toDTO)
+            .orElseThrow(() -> new UserNotFoundException("User with username " + username + " not found"));
+    }
+
+    public UserResponseDTO registerUser(RegisterUserRequestDTO dto, String ip) {
+        User user = mapper.toEntity(dto);
+        user.setIpAddress(ip);
+        try {
+            user = repo.save(user);
+        } catch (DataIntegrityViolationException e) {
+            throw new UserAlreadyExistsException("User with username " + dto.username() + " already exists");
+        }
+        return mapper.toDTO(user);
+    }
+}

--- a/backend/user-service/src/test/java/rs/raf/userservice/service/UserServiceTest.java
+++ b/backend/user-service/src/test/java/rs/raf/userservice/service/UserServiceTest.java
@@ -1,0 +1,173 @@
+package rs.raf.userservice.service;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import static org.mockito.Mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.dao.DataIntegrityViolationException;
+
+import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
+import rs.raf.userservice.dto.user.UserResponseDTO;
+import rs.raf.userservice.error.UserAlreadyExistsException;
+import rs.raf.userservice.error.UserNotFoundException;
+import rs.raf.userservice.mapper.UserMapper;
+import rs.raf.userservice.model.User;
+import rs.raf.userservice.model.UserRole;
+import rs.raf.userservice.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository repo;
+
+    @Mock
+    private UserMapper mapper;
+
+    @InjectMocks
+    private UserService service;
+
+    private User buildUser(Long id, String username) {
+        return new User()
+            .setId(id)
+            .setUsername(username)
+            .setPassword("secret")
+            .setEmail(username + "@example.com")
+            .setFirstName("John")
+            .setLastName("Doe")
+            .setIpAddress("127.0.0.1")
+            .setRole(UserRole.CUSTOMER);
+    }
+
+    private UserResponseDTO buildDTO(User user) {
+        return new UserResponseDTO(
+            user.getId(),
+            user.getUsername(),
+            user.getEmail(),
+            user.getFirstName(),
+            user.getLastName(),
+            user.getRole().name()
+        );
+    }
+
+    @Test
+    void shouldReturnAllUsers() {
+        User user1 = buildUser(1L, "alice");
+        User user2 = buildUser(2L, "bob");
+        UserResponseDTO dto1 = buildDTO(user1);
+        UserResponseDTO dto2 = buildDTO(user2);
+
+        when(repo.findAll()).thenReturn(List.of(user1, user2));
+        when(mapper.toDTO(user1)).thenReturn(dto1);
+        when(mapper.toDTO(user2)).thenReturn(dto2);
+
+        List<UserResponseDTO> result = service.getAll();
+
+        assertEquals(2, result.size());
+        assertEquals(dto1, result.get(0));
+        assertEquals(dto2, result.get(1));
+    }
+
+    @Test
+    void shouldReturnEmptyListWhenNoUsers() {
+        when(repo.findAll()).thenReturn(List.of());
+
+        List<UserResponseDTO> result = service.getAll();
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldReturnUserById() {
+        User user = buildUser(1L, "alice");
+        UserResponseDTO dto = buildDTO(user);
+
+        when(repo.findById(1L)).thenReturn(Optional.of(user));
+        when(mapper.toDTO(user)).thenReturn(dto);
+
+        UserResponseDTO result = service.getById(1L);
+
+        assertEquals(dto, result);
+    }
+
+    @Test
+    void shouldThrowWhenUserByIdNotFound() {
+        when(repo.findById(99L)).thenReturn(Optional.empty());
+
+        UserNotFoundException ex = assertThrows(
+            UserNotFoundException.class,
+            () -> service.getById(99L)
+        );
+
+        assertEquals("User with id 99 not found", ex.getMessage());
+    }
+
+    @Test
+    void shouldReturnUserByUsername() {
+        User user = buildUser(1L, "alice");
+        UserResponseDTO dto = buildDTO(user);
+
+        when(repo.findByUsername("alice")).thenReturn(Optional.of(user));
+        when(mapper.toDTO(user)).thenReturn(dto);
+
+        UserResponseDTO result = service.getByUsername("alice");
+
+        assertEquals(dto, result);
+    }
+
+    @Test
+    void shouldThrowWhenUserByUsernameNotFound() {
+        when(repo.findByUsername("ghost")).thenReturn(Optional.empty());
+
+        UserNotFoundException ex = assertThrows(
+            UserNotFoundException.class,
+            () -> service.getByUsername("ghost")
+        );
+
+        assertEquals("User with username ghost not found", ex.getMessage());
+    }
+
+    @Test
+    void shouldRegisterUserAndSetIpAddress() {
+        RegisterUserRequestDTO dto = new RegisterUserRequestDTO(
+            "alice", "secret", "alice@example.com", "Alice", "Smith"
+        );
+        User unsaved = buildUser(null, "alice").setIpAddress(null);
+        User saved = buildUser(1L, "alice");
+        UserResponseDTO responseDTO = buildDTO(saved);
+
+        when(mapper.toEntity(dto)).thenReturn(unsaved);
+        when(repo.save(unsaved)).thenReturn(saved);
+        when(mapper.toDTO(saved)).thenReturn(responseDTO);
+
+        UserResponseDTO result = service.registerUser(dto, "192.168.1.1");
+
+        assertEquals("192.168.1.1", unsaved.getIpAddress());
+        assertEquals(responseDTO, result);
+        verify(repo).save(unsaved);
+    }
+
+    @Test
+    void shouldThrowWhenRegisteringDuplicateUser() {
+        RegisterUserRequestDTO dto = new RegisterUserRequestDTO(
+            "alice", "secret", "alice@example.com", "Alice", "Smith"
+        );
+        User unsaved = buildUser(null, "alice").setIpAddress(null);
+
+        when(mapper.toEntity(dto)).thenReturn(unsaved);
+        when(repo.save(unsaved)).thenThrow(new DataIntegrityViolationException("duplicate"));
+
+        UserAlreadyExistsException ex = assertThrows(
+            UserAlreadyExistsException.class,
+            () -> service.registerUser(dto, "192.168.1.1")
+        );
+
+        assertEquals("User with username alice already exists", ex.getMessage());
+    }
+}


### PR DESCRIPTION
Implemented the registration endpoint at POST /api/v1/users. Endpoints exist to get all users (GET /api/v1/users), get by ID (GET /api/v1/users/id), and get by username (GET /api/v1/users/username/username).

Two DTO objects have been added. RegisterUserRequestDTO and UserResponseDTO. ErrorResponseDTO is also there, used in global exception handler methods. All DTOs use validation. Mapping is done by simple mapper classes.

Unit tests have been written for the service layer. They are minimal, and just test existing methods.

Swagger documentation exists for all endpoints.

Refs #3 and, except for the email verification, mostly resolves #6. Email verification can be added later, but I don't believe there is enough time for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user management REST API: register users, list users, get by ID or username.
  * Request/response DTOs with validation to ensure correct registration input.
* **Error Handling**
  * Centralized, standardized error responses for validation errors, not-found, and duplicate-user cases.
* **Documentation**
  * OpenAPI/Swagger metadata added for endpoints and schemas.
* **Tests**
  * Unit tests covering service behavior, registration, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->