### PR TITLE
Add JWT authentication

### DIFF
--- a/backend/user-service/src/main/java/rs/raf/userservice/UserServiceApplication.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/UserServiceApplication.java
@@ -5,9 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class UserServiceApplication {
-
     public static void main(String[] args) {
         SpringApplication.run(UserServiceApplication.class, args);
     }
-
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package rs.raf.userservice.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -26,7 +27,7 @@ public class SecurityConfig {
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
             .authorizeHttpRequests(auth ->
-                auth.requestMatchers("/api/v1/users").permitAll()
+                auth.requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
                 .requestMatchers("/api/v1/users/login").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()

--- a/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
@@ -1,0 +1,26 @@
+package rs.raf.userservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .csrf(csrf -> csrf.disable())
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth ->
+                auth.requestMatchers("/api/v1/users").permitAll()
+                .requestMatchers("/api/v1/users/login").permitAll()
+                .anyRequest().authenticated()
+            );
+
+        return http.build();
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
@@ -5,11 +5,24 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import rs.raf.userservice.security.CustomUserService;
+import rs.raf.userservice.security.JWTFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+    private final JWTFilter jwtFilter;
+    private final CustomUserService customUserService;
+
+    public SecurityConfig(JWTFilter jwtFilter, CustomUserService customUserService) {
+        this.jwtFilter = jwtFilter;
+        this.customUserService = customUserService;
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
@@ -19,8 +32,14 @@ public class SecurityConfig {
                 auth.requestMatchers("/api/v1/users").permitAll()
                 .requestMatchers("/api/v1/users/login").permitAll()
                 .anyRequest().authenticated()
-            );
+            )
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
@@ -9,18 +9,15 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
-import rs.raf.userservice.security.CustomUserService;
 import rs.raf.userservice.security.JWTFilter;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
     private final JWTFilter jwtFilter;
-    private final CustomUserService customUserService;
 
-    public SecurityConfig(JWTFilter jwtFilter, CustomUserService customUserService) {
+    public SecurityConfig(JWTFilter jwtFilter) {
         this.jwtFilter = jwtFilter;
-        this.customUserService = customUserService;
     }
 
     @Bean
@@ -31,6 +28,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth ->
                 auth.requestMatchers("/api/v1/users").permitAll()
                 .requestMatchers("/api/v1/users/login").permitAll()
+                .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -67,7 +67,7 @@ public class UserController {
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "Created"),
         @ApiResponse(responseCode = "400", description = "Bad request"),
-        @ApiResponse(responseCode = "409", description = "Conflict")
+        @ApiResponse(responseCode = "404", description = "Not found"),
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User registration data", required = true)
     @PostMapping

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -67,7 +67,7 @@ public class UserController {
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "Created"),
         @ApiResponse(responseCode = "400", description = "Bad request"),
-        @ApiResponse(responseCode = "404", description = "Not found"),
+        @ApiResponse(responseCode = "409", description = "Conflict"),
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User registration data", required = true)
     @PostMapping
@@ -83,7 +83,7 @@ public class UserController {
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "Bad request"),
-        @ApiResponse(responseCode = "409", description = "Conflict")
+        @ApiResponse(responseCode = "404", description = "Not found"),
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User login data", required = true)
     @PostMapping("/login")

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -15,8 +15,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
-import rs.raf.userservice.dto.user.UserResponseDTO;
+import rs.raf.userservice.dto.user.*;
 import rs.raf.userservice.service.UserService;
 
 @RestController
@@ -77,5 +76,13 @@ public class UserController {
         String ip = httpRequest.getRemoteAddr();
         var response = service.registerUser(requestDTO, ip);
         return ResponseEntity.status(201).body(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponseDTO> loginUser(
+            @RequestBody @Valid LoginRequestDTO request
+    ) {
+        var response = service.loginUser(request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -13,11 +13,13 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import rs.raf.userservice.dto.user.*;
 import rs.raf.userservice.service.UserService;
 
+@Tag(name = "User Controller", description = "Endpoints for managing users")
 @RestController
 @RequestMapping("/api/v1/users")
 public class UserController {

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -80,6 +80,12 @@ public class UserController {
         return ResponseEntity.status(201).body(response);
     }
 
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Bad request"),
+        @ApiResponse(responseCode = "409", description = "Conflict")
+    })
+    @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User login data", required = true)
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDTO> loginUser(
             @RequestBody @Valid LoginRequestDTO request

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/user/LoginRequestDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/user/LoginRequestDTO.java
@@ -1,0 +1,16 @@
+package rs.raf.userservice.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "DTO for user login request")
+public record LoginRequestDTO(
+    @Schema(description = "Username of the user", example = "john_doe")
+    @NotBlank
+    String username,
+    @Schema(description = "Password of the user", example = "P@ssw0rd")
+    @NotBlank
+    @Size(min = 8)
+    String password
+) {}

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/user/LoginResponseDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/user/LoginResponseDTO.java
@@ -1,0 +1,16 @@
+package rs.raf.userservice.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import rs.raf.userservice.model.UserRole;
+
+@Schema(description = "DTO for user login response")
+public record LoginResponseDTO(
+    @Schema(description = "User ID", example = "1")
+    Long id,
+    @Schema(description = "Username", example = "john_doe")
+    String username,
+    @Schema(description = "User role", example = "CUSTOMER")
+    UserRole role,
+    @Schema(description = "JWT token for authentication", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    String jwt
+) {}

--- a/backend/user-service/src/main/java/rs/raf/userservice/dto/user/RegisterUserRequestDTO.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/dto/user/RegisterUserRequestDTO.java
@@ -14,7 +14,7 @@ public record RegisterUserRequestDTO(
     String password,
     @Schema(description = "Email of the new user", example = "jdoe@example.com")
     @NotBlank
-    @Email
+    @Email(message = "Email should be valid")
     String email,
     @Schema(description = "First name of the new user", example = "John")
     String firstName,

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -13,36 +13,30 @@ import rs.raf.userservice.dto.ErrorResponseDTO;
 public class GlobalExceptionHandler {
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ErrorResponseDTO> handleUserNotFoundException(UserNotFoundException ex) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
-            404,
-            LocalDateTime.now(),
-            ex.getMessage()
-        );
-        return ResponseEntity.status(404).body(errorResponse);
+        return buildResponse(404, ex.getMessage());
     }
 
     @ExceptionHandler(UserAlreadyExistsException.class)
     public ResponseEntity<ErrorResponseDTO> handleUserAlreadyExistsException(UserAlreadyExistsException ex) {
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
-            409,
-            LocalDateTime.now(),
-            ex.getMessage()
-        );
-        return ResponseEntity.status(409).body(errorResponse);
+        return buildResponse(409, ex.getMessage());
     }
 
-    // Not great, but it works for now
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponseDTO> handleValidationExceptions(MethodArgumentNotValidException ex) {
         StringBuilder errorMessage = new StringBuilder("Validation failed:\n");
         ex.getBindingResult().getFieldErrors().forEach(error -> {
             errorMessage.append(String.format("Field '%s': %s\n", error.getField(), error.getDefaultMessage()));
         });
-        ErrorResponseDTO errorResponse = new ErrorResponseDTO(
-            400,
-            LocalDateTime.now(),
-            errorMessage.toString().trim()
-        );
-        return ResponseEntity.status(400).body(errorResponse);
+        return buildResponse(400, errorMessage.toString().trim());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDTO> handleGenericException(Exception ex) {
+        return buildResponse(500, "An unexpected error occurred: " + ex.getMessage());
+    }
+
+    private ResponseEntity<ErrorResponseDTO> buildResponse(int status, String message) {
+        ErrorResponseDTO dto = new ErrorResponseDTO(status, LocalDateTime.now(), message);
+        return ResponseEntity.status(status).body(dto);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponseDTO> handleGenericException(Exception ex) {
-        return buildResponse(500, "An unexpected error occurred: " + ex.getMessage());
+        return buildResponse(500, "An unexpected error occurred");
     }
 
     private ResponseEntity<ErrorResponseDTO> buildResponse(int status, String message) {

--- a/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package rs.raf.userservice.mapper;
 
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import rs.raf.userservice.dto.user.RegisterUserRequestDTO;
@@ -9,10 +10,16 @@ import rs.raf.userservice.model.UserRole;
 
 @Component
 public class UserMapper {
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public UserMapper(BCryptPasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
     public User toEntity(RegisterUserRequestDTO dto) {
         return new User()
             .setUsername(dto.username())
-            .setPassword(dto.password()) // TODO: hash passwords
+            .setPassword(passwordEncoder.encode(dto.password()))
             .setEmail(dto.email())
             .setFirstName(dto.firstName())
             .setLastName(dto.lastName())

--- a/backend/user-service/src/main/java/rs/raf/userservice/security/CustomUserDetails.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/security/CustomUserDetails.java
@@ -20,9 +20,7 @@ public class CustomUserDetails implements UserDetails {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(
-            new SimpleGrantedAuthority("ROLE_USER"),
-            new SimpleGrantedAuthority("ROLE_ADMIN"),
-            new SimpleGrantedAuthority("ROLE_CUSTOMER")
+            new SimpleGrantedAuthority("ROLE_USER")
         );
     }
 

--- a/backend/user-service/src/main/java/rs/raf/userservice/security/CustomUserDetails.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/security/CustomUserDetails.java
@@ -1,0 +1,38 @@
+package rs.raf.userservice.security;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import rs.raf.userservice.model.User;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+            new SimpleGrantedAuthority("ROLE_USER"),
+            new SimpleGrantedAuthority("ROLE_ADMIN"),
+            new SimpleGrantedAuthority("ROLE_CUSTOMER")
+        );
+    }
+
+    @Override
+    public @Nullable String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/security/CustomUserService.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/security/CustomUserService.java
@@ -1,0 +1,26 @@
+package rs.raf.userservice.security;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import rs.raf.userservice.model.User;
+import rs.raf.userservice.repository.UserRepository;
+
+@Service
+public class CustomUserService implements UserDetailsService {
+    private final UserRepository repo;
+
+    public CustomUserService(UserRepository repo) {
+        this.repo = repo;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = repo.findByUsername(username)
+            .orElseThrow(() -> new UsernameNotFoundException("User with username " + username + " not found"));
+
+        return new CustomUserDetails(user);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/security/JWTFilter.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/security/JWTFilter.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -29,24 +30,29 @@ public class JWTFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         String authHeader = request.getHeader("Authorization");
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            doFilter(request, response, filterChain);
+            filterChain.doFilter(request, response);
             return;
         }
 
         String token = authHeader.substring(7);
         String username = jwtUtil.verify(token);
         if (username == null || SecurityContextHolder.getContext().getAuthentication() != null) {
-            doFilter(request, response, filterChain);
+            filterChain.doFilter(request, response);
             return;
         }
 
-        UserDetails user = service.loadUserByUsername(username);
-        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
-            user,
-            null,
-            user.getAuthorities()
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
-        doFilter(request, response, filterChain);
+        try {
+            UserDetails user = service.loadUserByUsername(username);
+            UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+                user,
+                null,
+                user.getAuthorities()
+            );
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        } catch (UsernameNotFoundException e) {
+            SecurityContextHolder.clearContext();
+        }
+
+        filterChain.doFilter(request, response);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/security/JWTFilter.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/security/JWTFilter.java
@@ -1,0 +1,52 @@
+package rs.raf.userservice.security;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import rs.raf.userservice.util.JWTUtil;
+
+@Component
+public class JWTFilter extends OncePerRequestFilter {
+    private final JWTUtil jwtUtil;
+    private CustomUserService service;
+
+    public JWTFilter(JWTUtil jwtUtil, CustomUserService service) {
+        this.jwtUtil = jwtUtil;
+        this.service = service;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String authHeader = request.getHeader("Authorization");
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            doFilter(request, response, filterChain);
+            return;
+        }
+
+        String token = authHeader.substring(7);
+        String username = jwtUtil.verify(token);
+        if (username == null) {
+            doFilter(request, response, filterChain);
+            return;
+        }
+
+        UserDetails user = service.loadUserByUsername(username);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(
+            user,
+            null,
+            user.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+        doFilter(request, response, filterChain);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/security/JWTFilter.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/security/JWTFilter.java
@@ -35,7 +35,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         String token = authHeader.substring(7);
         String username = jwtUtil.verify(token);
-        if (username == null) {
+        if (username == null || SecurityContextHolder.getContext().getAuthentication() != null) {
             doFilter(request, response, filterChain);
             return;
         }

--- a/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
@@ -3,6 +3,7 @@ package rs.raf.userservice.service;
 import java.util.List;
 
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import rs.raf.userservice.dto.user.*;
@@ -11,15 +12,25 @@ import rs.raf.userservice.error.UserNotFoundException;
 import rs.raf.userservice.mapper.UserMapper;
 import rs.raf.userservice.model.User;
 import rs.raf.userservice.repository.UserRepository;
+import rs.raf.userservice.util.JWTUtil;
 
 @Service
 public class UserService {
     private final UserRepository repo;
     private final UserMapper mapper;
+    private final JWTUtil jwt;
+    private final BCryptPasswordEncoder passwords;
 
-    public UserService(UserRepository repo, UserMapper mapper) {
+    public UserService(
+        UserRepository repo,
+        UserMapper mapper,
+        JWTUtil jwt,
+        BCryptPasswordEncoder passwords
+    ) {
         this.repo = repo;
         this.mapper = mapper;
+        this.jwt = jwt;
+        this.passwords = passwords;
     }
 
     public List<UserResponseDTO> getAll() {
@@ -47,5 +58,22 @@ public class UserService {
             throw new UserAlreadyExistsException("User with username " + dto.username() + " already exists");
         }
         return mapper.toDTO(user);
+    }
+
+    public LoginResponseDTO loginUser(LoginRequestDTO dto) {
+        User user = repo.findByUsername(dto.username())
+            .orElseThrow(() -> new UserNotFoundException("User with username " + dto.username() + " not found"));
+
+        if (!passwords.matches(dto.password(), user.getPassword())) {
+            throw new UserNotFoundException("Invalid password");
+        }
+
+        String token = jwt.issue(user.getUsername());
+        return new LoginResponseDTO(
+            user.getId(),
+            user.getUsername(),
+            user.getRole(),
+            token
+        );
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
@@ -62,10 +62,10 @@ public class UserService {
 
     public LoginResponseDTO loginUser(LoginRequestDTO dto) {
         User user = repo.findByUsername(dto.username())
-            .orElseThrow(() -> new UserNotFoundException("User with username " + dto.username() + " not found"));
+            .orElseThrow(() -> new UserNotFoundException("Username and password do not match"));
 
         if (!passwords.matches(dto.password(), user.getPassword())) {
-            throw new UserNotFoundException("Invalid password");
+            throw new UserNotFoundException("Username and password do not match");
         }
 
         String token = jwt.issue(user.getUsername());

--- a/backend/user-service/src/main/java/rs/raf/userservice/util/JWTUtil.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/util/JWTUtil.java
@@ -1,0 +1,38 @@
+package rs.raf.userservice.util;
+
+import java.security.KeyPair;
+import java.util.Date;
+
+import org.springframework.stereotype.Component;
+
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+
+@Component
+public class JWTUtil {
+    private final KeyPair keys = Jwts.SIG.EdDSA.keyPair().build();
+
+    public String issue(String username) {
+        return Jwts.builder()
+            .issuer("RAF")
+            .subject(username)
+            .issuedAt(new Date())
+            .expiration(new Date(System.currentTimeMillis() + 3600000))
+            .signWith(keys.getPrivate())
+            .compact();
+    }
+
+    public String verify(String jwt) {
+        try {
+            return Jwts.parser()
+                .requireIssuer("RAF")
+                .verifyWith(keys.getPublic())
+                .build()
+                .parseSignedClaims(jwt)
+                .getPayload()
+                .getSubject();
+        } catch (JwtException e) {
+            return null;
+        }
+    }
+}

--- a/backend/user-service/src/main/resources/application.properties
+++ b/backend/user-service/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 spring.application.name=user-service
+spring.datasource.url=jdbc:h2:mem:userdb
+spring.datasource.driverClassName=org.h2.Driver
 server.port=8081

--- a/backend/user-service/src/test/python/test.py
+++ b/backend/user-service/src/test/python/test.py
@@ -1,0 +1,27 @@
+import requests
+
+
+reg = {
+    "username": "stiboly",
+    "password": "xx123123123xx",
+    "email": "landric6124si@raf.rs",
+}
+res = requests.post("http://localhost:8081/api/v1/users", json=reg)
+print(f"Response is 201? {res.status_code == 201}")
+print(res.json())
+
+login = {
+    "username": "stiboly",
+    "password": "xx123123123xx"
+}
+res = requests.post("http://localhost:8081/api/v1/users/login", json=login)
+print(f"Response is 200? {res.status_code == 200}")
+print(res.json())
+token = res.json()["jwt"]
+
+res = requests.get(
+    "http://localhost:8081/api/v1/users/1",
+    headers={"Authorization": f"Bearer {token}"}
+)
+print(f"Response is 200? {res.status_code == 200}")
+print(res.json())


### PR DESCRIPTION
Added JWT auth. A new endpoint POST /api/v1/users/login has been added which issues EdRSA signed JWT tokens. The key pair is, for the sake of simplicity, not saved and regenerated on every service restart. JWTFilter which extends OncePerRequestFilter is used to validate tokens on each request. It is part of a filter chain controlled by Spring Security. SecurityConfig configures which requests are allowed and which ones are not, along with disabling CSRF and setting a stateless session policy.

Two new DTOs have been added, LoginRequestDTO and LoginResponseDTO. During login, a request DTO is sent with a username and password. After validation, a response DTO is returned containing a JWT token. Except for the login and registration endpoints, everything else must be accessed with an authorization header containing the right token.

A single integration test exists, testing registration, login, and JWT auth. It is located in the test directory under python, written in Python and using requests.

Refs #3 and resolves #1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user login endpoint and token-based authentication protecting API endpoints

* **Improvements**
  * Issued JWTs for authenticated sessions
  * Passwords are now stored hashed
  * Email validation returns a clearer error message
  * Generic server errors now return a standardized message

* **Tests**
  * Added an integration script exercising registration, login, and authenticated user retrieval
<!-- end of auto-generated comment: release notes by coderabbit.ai -->