### PR TITLE
Implement banning

### DIFF
--- a/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
@@ -28,11 +28,14 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth ->
-                auth.requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
+            .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
                 .requestMatchers("/api/v1/users/username/**").permitAll()
                 .requestMatchers("/api/v1/users/login").permitAll()
                 .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
+                .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers("/api/v1/bans/**").hasRole("ADMINISTRATOR")
                 .anyRequest().authenticated()
             )
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable())
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+            .headers(headers -> headers.frameOptions(fo -> fo.sameOrigin()))
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/api/v1/users").permitAll()
                 .requestMatchers("/api/v1/users/username/**").permitAll()

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/BanController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/BanController.java
@@ -1,0 +1,61 @@
+package rs.raf.userservice.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import rs.raf.userservice.service.BanService;
+
+@Tag(name = "BanController", description = "Controller for managing banned IP addresses")
+@RestController
+@RequestMapping("/api/v1/bans")
+public class BanController {
+    private final BanService service;
+
+    public BanController(BanService service) {
+        this.service = service;
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
+    @GetMapping
+    public ResponseEntity<List<String>> getAll() {
+        var response = service.getAll();
+        return ResponseEntity.ok(response);
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "No content"),
+        @ApiResponse(responseCode = "403", description = "Forbidden")
+    })
+    @Parameter(name = "ip", description = "IP address to ban", required = true)
+    @PostMapping
+    public ResponseEntity<Void> ban(@RequestParam String ip) {
+        service.ban(ip);
+        return ResponseEntity.noContent().build();
+    }
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "204", description = "No content"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
+        @ApiResponse(responseCode = "404", description = "Not found")
+    })
+    @Parameter(name = "ip", description = "IP address to unban", required = true)
+    @DeleteMapping
+    public ResponseEntity<Void> unban(@RequestParam String ip) {
+        service.unban(ip);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/controller/UserController.java
@@ -32,8 +32,7 @@ public class UserController {
     }
 
     @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "OK"),
-        @ApiResponse(responseCode = "204", description = "No content")
+        @ApiResponse(responseCode = "200", description = "OK")
     })
     @GetMapping
     public ResponseEntity<List<UserResponseDTO>> getAll() {
@@ -66,21 +65,23 @@ public class UserController {
     @ApiResponses({
         @ApiResponse(responseCode = "201", description = "Created"),
         @ApiResponse(responseCode = "400", description = "Bad request"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
         @ApiResponse(responseCode = "409", description = "Conflict"),
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User registration data", required = true)
     @PostMapping
     public ResponseEntity<UserResponseDTO> registerUser(
-            @RequestBody @Valid RegisterUserRequestDTO requestDTO,
-            HttpServletRequest httpRequest
+            @RequestBody @Valid RegisterUserRequestDTO dto,
+            HttpServletRequest request
     ) {
-        String ip = httpRequest.getRemoteAddr();
-        var response = service.registerUser(requestDTO, ip);
+        String ip = request.getRemoteAddr();
+        var response = service.registerUser(dto, ip);
         return ResponseEntity.status(201).body(response);
     }
 
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
+        @ApiResponse(responseCode = "400", description = "Bad request"),
         @ApiResponse(responseCode = "403", description = "Forbidden"),
         @ApiResponse(responseCode = "404", description = "Not found"),
         @ApiResponse(responseCode = "409", description = "Conflict"),
@@ -113,14 +114,17 @@ public class UserController {
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "OK"),
         @ApiResponse(responseCode = "400", description = "Bad request"),
+        @ApiResponse(responseCode = "403", description = "Forbidden"),
         @ApiResponse(responseCode = "404", description = "Not found"),
     })
     @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "User login data", required = true)
     @PostMapping("/login")
     public ResponseEntity<LoginResponseDTO> loginUser(
-            @RequestBody @Valid LoginRequestDTO request
+            @RequestBody @Valid LoginRequestDTO dto,
+            HttpServletRequest request
     ) {
-        var response = service.loginUser(request);
+        String ip = request.getRemoteAddr();
+        var response = service.loginUser(dto, ip);
         return ResponseEntity.ok(response);
     }
 }

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/BanNotFoundException.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/BanNotFoundException.java
@@ -1,0 +1,7 @@
+package rs.raf.userservice.error;
+
+public class BanNotFoundException extends RuntimeException {
+    public BanNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/BannedUserException.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/BannedUserException.java
@@ -1,0 +1,7 @@
+package rs.raf.userservice.error;
+
+public class BannedUserException extends RuntimeException {
+    public BannedUserException(String message) {
+        super(message);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/error/GlobalExceptionHandler.java
@@ -27,6 +27,16 @@ public class GlobalExceptionHandler {
         return buildResponse(403, ex.getMessage());
     }
 
+    @ExceptionHandler(BannedUserException.class)
+    public ResponseEntity<ErrorResponseDTO> handleBannedUserException(BannedUserException ex) {
+        return buildResponse(403, ex.getMessage());
+    }
+
+    @ExceptionHandler(BanNotFoundException.class)
+    public ResponseEntity<ErrorResponseDTO> handleBanNotFoundException(BanNotFoundException ex) {
+        return buildResponse(404, ex.getMessage());
+    }
+
     @ExceptionHandler(AuthorizationDeniedException.class)
     public ResponseEntity<ErrorResponseDTO> handleAuthorizationDeniedException(AuthorizationDeniedException ex) {
         return buildResponse(403, "Access denied, don't even try");

--- a/backend/user-service/src/main/java/rs/raf/userservice/model/Ban.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/model/Ban.java
@@ -1,0 +1,25 @@
+package rs.raf.userservice.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Entity
+@Table(name = "bans")
+@Getter
+@Setter
+@Accessors(chain = true)
+public class Ban {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String ipAddress;
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/repository/BanRepository.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/repository/BanRepository.java
@@ -1,0 +1,13 @@
+package rs.raf.userservice.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import rs.raf.userservice.model.Ban;
+
+public interface BanRepository extends JpaRepository<Ban, Long> {
+    boolean existsByIpAddress(String ipAddress);
+
+    Optional<Ban> findByIpAddress(String ipAddress);
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/service/BanService.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/service/BanService.java
@@ -1,0 +1,33 @@
+package rs.raf.userservice.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import rs.raf.userservice.error.BanNotFoundException;
+import rs.raf.userservice.model.Ban;
+import rs.raf.userservice.repository.BanRepository;
+
+@Service
+public class BanService {
+    private final BanRepository repo;
+
+    public BanService(BanRepository repo) {
+        this.repo = repo;
+    }
+
+    public List<String> getAll() {
+        return repo.findAll().stream().map(Ban::getIpAddress).toList();
+    }
+
+    public void ban(String ip) {
+        Ban ban = new Ban().setIpAddress(ip);
+        repo.save(ban);
+    }
+
+    public void unban(String ip) {
+        Ban ban = repo.findByIpAddress(ip)
+            .orElseThrow(() -> new BanNotFoundException("Ban with IP address " + ip + " not found"));
+        repo.delete(ban);
+    }
+}

--- a/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
+++ b/backend/user-service/src/main/java/rs/raf/userservice/service/UserService.java
@@ -9,28 +9,33 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import rs.raf.userservice.dto.user.*;
+import rs.raf.userservice.error.BannedUserException;
 import rs.raf.userservice.error.PasswordMismatchException;
 import rs.raf.userservice.error.UserAlreadyExistsException;
 import rs.raf.userservice.error.UserNotFoundException;
 import rs.raf.userservice.mapper.UserMapper;
 import rs.raf.userservice.model.User;
+import rs.raf.userservice.repository.BanRepository;
 import rs.raf.userservice.repository.UserRepository;
 import rs.raf.userservice.util.JWTUtil;
 
 @Service
 public class UserService {
     private final UserRepository repo;
+    private final BanRepository bans;
     private final UserMapper mapper;
     private final JWTUtil jwt;
     private final BCryptPasswordEncoder passwords;
 
     public UserService(
         UserRepository repo,
+        BanRepository bans,
         UserMapper mapper,
         JWTUtil jwt,
         BCryptPasswordEncoder passwords
     ) {
         this.repo = repo;
+        this.bans = bans;
         this.mapper = mapper;
         this.jwt = jwt;
         this.passwords = passwords;
@@ -53,6 +58,10 @@ public class UserService {
     }
 
     public UserResponseDTO registerUser(RegisterUserRequestDTO dto, String ip) {
+        if (bans.existsByIpAddress(ip)) {
+            throw new BannedUserException("Registration from IP address " + ip + " is banned");
+        }
+
         User user = mapper.toEntity(dto);
         user.setIpAddress(ip);
         try {
@@ -60,6 +69,7 @@ public class UserService {
         } catch (DataIntegrityViolationException e) {
             throw new UserAlreadyExistsException("User with username " + dto.username() + " or email " + dto.email() + " already exists");
         }
+
         return mapper.toDTO(user);
     }
 
@@ -99,7 +109,11 @@ public class UserService {
         repo.delete(user);
     }
 
-    public LoginResponseDTO loginUser(LoginRequestDTO dto) {
+    public LoginResponseDTO loginUser(LoginRequestDTO dto, String ip) {
+        if (bans.existsByIpAddress(ip)) {
+            throw new BannedUserException("Login from IP address " + ip + " is banned");
+        }
+
         User user = repo.findByUsername(dto.username())
             .orElseThrow(() -> new UserNotFoundException("Username and password do not match"));
 


### PR DESCRIPTION
Implemented banning of IP addresses. In the new BanController, there are three new endpoints under /api/v1/bans. GET / retrieves all banned IP addresses, POST /?ip=... bans the specified IP, and DELETE /?ip=... unbans it.
All ban data is stored in the Ban model in the DB. Only the IP address is saved for simplicity. It also must be unique. BanService ties the controller and the model/repository. Only admins can list, ban, or unban IP addresses.

Fixed Swagger docs and allowed access to the H2 console in Spring Security. Also updated UserController so that banned IPs cannot register or log in.

This PR resolves #8, completing the user/auth service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Added IP ban management system allowing administrators to view, add, and remove banned IP addresses.

* **Security**
  - Implemented IP-based access validation during user registration and login to block authentication attempts from banned IP addresses with appropriate error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->