### PR TITLE
Add Docker support for user and auth service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# This is an example .env file. You should copy this file to .env and fill in the values.
+DB_USER=user
+DB_PASSWORD=password
+
+# Database names
+USER_DB=userdb
+CAFE_DB=cafedb
+
+# Spring profile to use (dev, prod, etc.)
+APP_PROFILE=dev

--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,4 @@ USER_DB=userdb
 CAFE_DB=cafedb
 
 # Spring profile to use (dev, prod, etc.)
-APP_PROFILE=dev
+APP_PROFILE=prod

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+.env

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -1,7 +1,11 @@
 FROM eclipse-temurin:25-jdk-alpine AS build
 WORKDIR /app
-COPY . .
-RUN ./mvnw clean package -DskipTests
+COPY mvnw .
+COPY .mvn .mvn
+COPY pom.xml .
+RUN chmod +x mvnw && ./mvnw dependency:go-offline -B
+COPY src src
+RUN chmod +x mvnw && ./mvnw package -DskipTests -B
 
 FROM eclipse-temurin:25-jre-alpine
 WORKDIR /app

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -1,0 +1,10 @@
+FROM eclipse-temurin:25-jdk-alpine AS build
+WORKDIR /app
+COPY . .
+RUN ./mvnw clean package -DskipTests
+
+FROM eclipse-temurin:25-jre-alpine
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/user-service/pom.xml
+++ b/backend/user-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.5</version>
+        <version>4.0.6</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>rs.raf</groupId>

--- a/backend/user-service/src/main/resources/application-dev.properties
+++ b/backend/user-service/src/main/resources/application-dev.properties
@@ -1,0 +1,2 @@
+spring.datasource.url=jdbc:h2:mem:userdb
+spring.datasource.driverClassName=org.h2.Driver

--- a/backend/user-service/src/main/resources/application-prod.properties
+++ b/backend/user-service/src/main/resources/application-prod.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:postgresql://db:5432/${USER_DB:userdb}
+spring.datasource.username=${DB_USER:postgres}
+spring.datasource.password=${DB_PASSWORD:password}
+spring.datasource.driverClassName=org.postgresql.Driver
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=update

--- a/backend/user-service/src/main/resources/application-prod.properties
+++ b/backend/user-service/src/main/resources/application-prod.properties
@@ -1,6 +1,6 @@
-spring.datasource.url=jdbc:postgresql://db:5432/${USER_DB:userdb}
-spring.datasource.username=${DB_USER:postgres}
-spring.datasource.password=${DB_PASSWORD:password}
+spring.datasource.url=jdbc:postgresql://db:5432/${USER_DB}
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driverClassName=org.postgresql.Driver
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.hibernate.ddl-auto=update

--- a/backend/user-service/src/main/resources/application.properties
+++ b/backend/user-service/src/main/resources/application.properties
@@ -1,4 +1,3 @@
 spring.application.name=user-service
-spring.datasource.url=jdbc:h2:mem:userdb
-spring.datasource.driverClassName=org.h2.Driver
+spring.profiles.default=${APP_PROFILE:prod}
 server.port=8081

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,6 +5,8 @@ services:
       - "8081:8081"
     depends_on:
       - db
+    env_file:
+      - .env
     environment:
       - USER_DB=${USER_DB}
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   auth:
-    build: backend/auth
+    build: backend/user-service
     ports:
       - "8081:8081"
     depends_on:
@@ -19,7 +19,7 @@ services:
       - db_data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME} -h localhost"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d postgres"]
       interval: 1m30s
       timeout: 30s
       retries: 5

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,29 @@
+services:
+  auth:
+    build: backend/auth
+    ports:
+      - "8081:8081"
+    depends_on:
+      - db
+    environment:
+      - USER_DB=${USER_DB}
+
+  db:
+    image: postgres:18-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME} -h localhost"]
+      interval: 1m30s
+      timeout: 30s
+      retries: 5
+      start_period: 30s
+
+volumes:
+  db_data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -4,7 +4,8 @@ services:
     ports:
       - "8081:8081"
     depends_on:
-      - db
+      - db:
+        condition: service_healthy
     env_file:
       - .env
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -18,7 +18,7 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/var/lib/postgresql
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d postgres"]

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE userdb;
+CREATE DATABASE cafedb;


### PR DESCRIPTION
Added Docker support for the user and authentication service. A new Dockerfile file has been created in backend/user-service to manage the container. The base image is JDK 21 Alpine from Temurin. The container is optimized in such a way to take full advantage of layer cashing, utilizing build images. The app itself is served on a much smaller JRE, reducing size.

The user & auth DB service has been switched to PostgreSQL 18 Alpine. A Docker compose file (compose.yaml in the repo's root) is used for this. Env vars are used to set the DB user and password, as well as a DB name for each service (currently only user & auth). A .env.example file is provided to make this easier, as one only needs to copy .env.example to .env and modify that file accordingly.

Finally, the user and auth service has two Spring profiles, one for production, and one for development. They are also settable from .env, and the menu & order service is encouraged to do this too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Application is now containerized, enabling consistent and reproducible deployment across different operational environments.
  * Implemented environment-specific profiles with appropriately configured database backends for development and production scenarios.
  * Added orchestrated local development environment with integrated database services, automatic schema initialization, and service health monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->