### PR TITLE
Add Ansible configuration

### DIFF
--- a/ansible/application.properties.j2
+++ b/ansible/application.properties.j2
@@ -1,0 +1,3 @@
+spring.application.name=user-service
+spring.profiles.default=${APP_PROFILE:{{ profile }}}
+server.port={{ port }}

--- a/ansible/application.properties.j2
+++ b/ansible/application.properties.j2
@@ -1,3 +1,3 @@
 spring.application.name=user-service
 spring.profiles.default=${APP_PROFILE:{{ profile }}}
-server.port={{ port }}
+server.port={{ server_port }}

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -3,4 +3,4 @@ all:
     localhost:
       ansible_connection: local
       profile: prod
-      port: 8081
+      server_port: 8081

--- a/ansible/inventory.yaml
+++ b/ansible/inventory.yaml
@@ -1,0 +1,6 @@
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+      profile: prod
+      port: 8081

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,0 +1,8 @@
+- name: Deploy
+  hosts: all
+
+tasks:
+  - name: application.properties
+    ansible.builtin.template:
+      src: application.properties.j2
+      dest: /home/stiboly/RafCafe/backend/src/main/resources/application.properties

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,8 +1,8 @@
 - name: Deploy
   hosts: all
 
-tasks:
-  - name: application.properties
-    ansible.builtin.template:
-      src: application.properties.j2
-      dest: /home/stiboly/RafCafe/backend/src/main/resources/application.properties
+  tasks:
+    - name: application.properties
+      ansible.builtin.template:
+        src: application.properties.j2
+        dest: /home/stiboly/RafCafe/backend/user-service/src/main/resources/application.properties

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -5,4 +5,4 @@
     - name: application.properties
       ansible.builtin.template:
         src: application.properties.j2
-        dest: /home/stiboly/RafCafe/backend/user-service/src/main/resources/application.properties
+        dest: "{{ playbook_dir }}/../backend/user-service/src/main/resources/application.properties"


### PR DESCRIPTION
Added Ansible configuration for user-service deployment of application.properties. In the new ansible directory, three files exist. A playbook (playbook.yaml), the inventory (inventory.yaml), and a Jinja application.properties template (application.properties.j2). The inventory only contains one local host and a Spring current profile and port variables. The playbook contains only one task which parses and copies application.properties to its place on my local machine.

Please indicate if this is all that's required, as the Ansible structure is very minimal and aimed to be like that if there's nothing else to be added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured deployment infrastructure with templated application properties, production environment inventory setup, and automated deployment task to render and deploy application configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PetarStamenic/RafCafe/pull/25?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->